### PR TITLE
change npm install to npm ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ setup:
 	touch database/database.sqlite
 	php artisan migrate
 	php artisan db:seed
-	npm install
+	npm ci
 
 watch:
 	npm run watch


### PR DESCRIPTION
Npm ci is used to install all exact version dependencies or devDependencies from a package-lock (without modifying it) for continuous integration.