### PR TITLE
ci(pr-title): линтовать заголовок PR

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,24 @@
+name: PR Title
+
+# Заголовок PR обязан быть conventional commit: при squash-мерже он становится
+# сообщением коммита, а по нему release-please определяет, какой разряд версии
+# поднять. Проверка отдельных коммитов ветки намеренно не делается, чтобы не
+# мешать работе внутри PR.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Решение кампании от 11.08 (`docs/components-modernization.md`, «Решено с пользователем»): conventional commits принуждаются линтом заголовка PR, а не проверкой отдельных коммитов ветки. При squash-мерже заголовок PR и становится сообщением коммита, поэтому история остаётся чистой, а работа внутри ветки ничем не стеснена.

До этого репозитория решение не доехало: 12.08 пачке ставили зависимости и CI, а линт заголовка нет. В js- и python-пачках он стоит с самого начала.

Файл добавляется без изменений, копия канонической из python-пачки. На существующий CI он не влияет: триггер `pull_request_target`, отдельная джоба.

Проверка вступает в силу со следующего PR: `pull_request_target`-workflow берётся из базовой ветки, поэтому на этом PR она ещё не запускается.